### PR TITLE
Reload signing files each time sync is called

### DIFF
--- a/syncer_test.go
+++ b/syncer_test.go
@@ -31,7 +31,7 @@ func TestSync(t *testing.T) {
 		ip:        []string{ip1, ip2},
 		dns:       []string{dns1, dns2},
 		daysValid: 365,
-		signer:    signer,
+		getSigner: func() (certificate, error) { return signer, nil },
 	}
 
 	var m1, m2, m3, m4, m5 secretMock

--- a/tlser.go
+++ b/tlser.go
@@ -57,13 +57,13 @@ func main() {
 		dnsStrings = strings.Split(*dns, ",")
 	}
 
-	signer, err := readCa(*cacrt, *cakey)
-	if err != nil {
-		log.Fatalf("Failed to read CA files: %v", err)
-	}
-
 	if len(*k8sName) == 0 {
 		log.Print("No secret name provided, generating cert on stdout")
+
+		signer, err := readCa(*cacrt, *cakey)
+		if err != nil {
+			log.Fatalf("Failed to read CA files: %v", err)
+		}
 
 		rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
 		if err != nil {
@@ -104,7 +104,7 @@ func main() {
 		ip:        ipStrings,
 		dns:       dnsStrings,
 		daysValid: *expire,
-		signer:    signer,
+		getSigner: func() (certificate, error) { return readCa(*cacrt, *cakey) },
 	}
 
 	if syncInterval == time.Duration(0) {


### PR DESCRIPTION
Reloads signing files each time their used to check whether certificates are insync. This allows secrets mounted via a volume to automatically update when the secret changes.

Fixes #3.