### PR TITLE
Fix secret creation

### DIFF
--- a/syncer.go
+++ b/syncer.go
@@ -26,8 +26,12 @@ func (s syncer) sync() error {
 	}
 
 	priorSecret, err := s.secrets.getSecret(s.id)
-	if err != nil && !k8errors.IsNotFound(err) {
-		return fmt.Errorf("unable to retrieve secret %v: %w", s.id, err)
+	if err != nil {
+		if !k8errors.IsNotFound(err) {
+			return fmt.Errorf("unable to retrieve secret %v: %w", s.id, err)
+		}
+		// Ensure priorSecret is nil so we can check it later. NotFound doesn't guarantee it's nil.
+		priorSecret = nil
 	}
 
 	var previous certificate

--- a/syncer_test.go
+++ b/syncer_test.go
@@ -58,7 +58,7 @@ func TestSync(t *testing.T) {
 
 	// Creates the secret if NotFound
 	notFound := k8errors.NewNotFound(schema.GroupResource{Resource: "Secret"}, sync.id.name)
-	m2.On("getSecret", sync.id).Return((*secret)(nil), notFound)
+	m2.On("getSecret", sync.id).Return(&secret{}, notFound)
 	m2.On("setSecret", mock.AnythingOfType("*v1.Secret"), false).Return(nil)
 	sync.secrets = &m2
 	req.NoError(sync.sync())


### PR DESCRIPTION
If the call to get a secret returns a NotFound error, it appears to return a pointer to an empty secret rather than nil. Update code to account for that.

Fixes #8.