### PR TITLE
Add gosec scanning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,16 @@ jobs:
       with:
         args: run -v --deadline 3m
         golangci_lint_version: 1.29.0
+  gosec:
+    name: Scan with gosec
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+    - name: Run Gosec Security Scanner
+      uses: securego/gosec@v2.5.0
+      with:
+        args: ./...
   test:
     name: Test Go Stable
     runs-on: ubuntu-latest

--- a/secrets.go
+++ b/secrets.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+/* #nosec */
 const tlsSecretType = "kubernetes.io/tls"
 
 type secret = corev1.Secret

--- a/tlser.go
+++ b/tlser.go
@@ -142,6 +142,7 @@ func main() {
 }
 
 func readPem(file string) ([]byte, error) {
+	/* #nosec */
 	bytes, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read %v: %w", cacrt, err)


### PR DESCRIPTION
Adds gosec scanning for security issues. Excludes loading file from a CLI parameter and false-positive on `kubernetes.io/tls` string.