### PR TITLE
Add Snyk

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,27 @@
+name: Snyk
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Snyk monitor
+        if: github.event_name == 'push'
+        uses: snyk/actions/golang@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_PLATSVCS_KEY }}
+        with:
+          command: monitor
+          args: --org=puppet-platform-services
+      - name: Snyk test
+        if: github.event_name == 'pull_request'
+        uses: snyk/actions/golang@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_PLATSVCS_KEY }}
+        with:
+          command: test
+          args: --org=puppet-platform-services


### PR DESCRIPTION
For the moment we use `pull_request` triggers, which only work with pull requests from the main project (not forks).

We can later add `pull_request_target` to support PRs from forks, but would want to use a pattern like
```
on:
  pull_request_target:
    types: [labeled]

jobs:
 snyk_vanagon:
   runs-on: ubuntu-latest
   if: contains(github.event.pull_request.labels.*.name, 'safe to test')
```
to ensure we don't run unauthorized code that could leak the Snyk token.